### PR TITLE
Resolve some lint warnings

### DIFF
--- a/src/spdx3_validate/__init__.py
+++ b/src/spdx3_validate/__init__.py
@@ -1,1 +1,8 @@
-from .main import main  # noqa: F401
+# SPDX-FileCopyrightText: Copyright (c) 2024 Joshua Watt
+# SPDX-License-Identifier: MIT
+
+"""Initialization for spdx3_validate package."""
+
+from .main import main
+
+__all__ = ["main"]

--- a/src/spdx3_validate/__main__.py
+++ b/src/spdx3_validate/__main__.py
@@ -3,6 +3,9 @@
 # Copyright (c) 2024 Joshua Watt
 #
 # SPDX-License-Identifier: MIT
+
+"""Main entry point for SPDX 3 validation tool."""
+
 from .main import main
 
 main()

--- a/src/spdx3_validate/main.py
+++ b/src/spdx3_validate/main.py
@@ -2,35 +2,41 @@
 #
 # SPDX-License-Identifier: MIT
 
+"""Main module for SPDX 3 validation tool."""
+
 import argparse
-import halo
 import json
+import urllib.request
+import sys
+import textwrap
+
+from pathlib import Path
+
+import halo
 import jsonschema
 import pyshacl
 import rdflib
-import sys
-import textwrap
-import urllib.request
 
 from rdflib import RDF, RDFS, SH, URIRef
 
-from pathlib import Path
 from .version import VERSION
 from .spdx_versions import find_version, SPDX_VERSIONS
 
 
 def read_location(location):
+    """Read a file from a location."""
     if "://" in location:
         with urllib.request.urlopen(location) as f:
             return f.read()
     elif location == "-":
         return sys.stdin.read()
     else:
-        with Path(location).open("r") as f:
+        with Path(location).open("r", encoding="utf-8") as f:
             return f.read()
 
 
 def derives_from(cls, target, shacl_graph):
+    """Check if a class derives from another class."""
     if cls == target:
         return True
 
@@ -42,6 +48,7 @@ def derives_from(cls, target, shacl_graph):
 
 
 def check_graph(graph, shacl_graph, current_version, error_external):
+    """Check a graph against SHACL shapes."""
     errors = []
 
     conforms, results, _ = pyshacl.validate(
@@ -77,11 +84,6 @@ def check_graph(graph, shacl_graph, current_version, error_external):
                 external_spdxids.add(str(spdxid))
 
         def check_external_ref_error(r):
-            nonlocal results
-            nonlocal shacl_graph
-            nonlocal graph
-            nonlocal external_spdxids
-
             if (r, RDF.type, SH.ValidationResult) not in results:
                 return False
 
@@ -147,6 +149,7 @@ def check_graph(graph, shacl_graph, current_version, error_external):
 
 
 def iter_validation_errors(err):
+    """Iterate over all validation errors."""
     if err.context:
         for e in err.context:
             yield e
@@ -154,6 +157,7 @@ def iter_validation_errors(err):
 
 
 def print_schema_error(err, filename, indent=0):
+    """Print a JSON Schema validation error."""
     def print_err(e, indent, fn=None, message=False):
         loc = e.json_path
         if fn:
@@ -194,6 +198,7 @@ def print_schema_error(err, filename, indent=0):
 
 
 def main(cmdline_args=None):
+    """Main entry point for SPDX 3 validation tool."""
     parser = argparse.ArgumentParser(
         description=f"Validate SPDX 3 files Version {VERSION}"
     )
@@ -264,7 +269,8 @@ def main(cmdline_args=None):
             elif current_version != version:
                 spinner.fail()
                 print(
-                    f"{j} has incompatible version {version.pretty}. Other documents are {current_version.pretty}"
+                    f"{j} has incompatible version {version.pretty}. "
+                    f"Other documents are {current_version.pretty}"
                 )
                 return 1
 
@@ -311,20 +317,20 @@ def main(cmdline_args=None):
 
         if json_errors:
             print(f"ERROR: JSON Schema validation failed for {fn}:")
-            for e in json_errors:
-                print_schema_error(e, fn)
+            for err in json_errors:
+                print_schema_error(err, fn)
                 errors += 1
 
         with halo.Halo(f"Checking SHACL for {fn}", enabled=not args.quiet) as spinner:
-            e = check_graph(g, shacl_graph, current_version, True)
-            if e:
+            err = check_graph(g, shacl_graph, current_version, True)
+            if err:
                 spinner.fail()
             else:
                 spinner.succeed()
 
-        if e:
+        if err:
             print(f"ERROR: SHACL Validation failed for {fn}:")
-            print("\n".join(e))
+            print("\n".join(err))
             errors += 1
 
     if len(files) > 1 and args.check_merged:
@@ -334,15 +340,15 @@ def main(cmdline_args=None):
                 for _, _, g in files:
                     merged_g += g
 
-                e = check_graph(g, shacl_graph, current_version, False)
-                if e:
+                err = check_graph(g, shacl_graph, current_version, False)
+                if err:
                     spinner.fail()
                 else:
                     spinner.succeed()
 
-            if e:
+            if err:
                 print("ERROR: SHACL Validation failed on merged files:")
-                print("\n".join(e))
+                print("\n".join(err))
                 errors += 1
         else:
             print(

--- a/src/spdx3_validate/main.py
+++ b/src/spdx3_validate/main.py
@@ -158,6 +158,7 @@ def iter_validation_errors(err):
 
 def print_schema_error(err, filename, indent=0):
     """Print a JSON Schema validation error."""
+
     def print_err(e, indent, fn=None, message=False):
         loc = e.json_path
         if fn:

--- a/src/spdx3_validate/spdx_versions.py
+++ b/src/spdx3_validate/spdx_versions.py
@@ -16,7 +16,9 @@ SpdxVersion = namedtuple(
 
 def get_3_0_0_imports(graph):
     """Get imported SPDX IDs from an SPDX 3.0.0 graph."""
-    RDF_BASE = URIRef("https://spdx.org/rdf/3.0.0/terms/")  # pylint: disable=invalid-name
+    RDF_BASE = URIRef(
+        "https://spdx.org/rdf/3.0.0/terms/"
+    )  # pylint: disable=invalid-name
 
     for doc in graph.subjects(RDF.type, RDF_BASE + "Core/SpdxDocument"):
         for i in graph.objects(doc, RDF_BASE + "Core/imports"):
@@ -25,7 +27,9 @@ def get_3_0_0_imports(graph):
 
 def get_3_0_1_imports(graph):
     """Get imported SPDX IDs from an SPDX 3.0.1 graph."""
-    RDF_BASE = URIRef("https://spdx.org/rdf/3.0.1/terms/")  # pylint: disable=invalid-name
+    RDF_BASE = URIRef(
+        "https://spdx.org/rdf/3.0.1/terms/"
+    )  # pylint: disable=invalid-name
 
     for doc in graph.subjects(RDF.type, RDF_BASE + "Core/SpdxDocument"):
         for i in graph.objects(doc, RDF_BASE + "Core/import"):

--- a/src/spdx3_validate/spdx_versions.py
+++ b/src/spdx3_validate/spdx_versions.py
@@ -2,10 +2,11 @@
 #
 # SPDX-License-Identifier: MIT
 
+"""SPDX versions and related utilities."""
+
 from collections import namedtuple
 
 from rdflib import RDF, URIRef
-
 
 SpdxVersion = namedtuple(
     "SpdxVersion",
@@ -14,21 +15,21 @@ SpdxVersion = namedtuple(
 
 
 def get_3_0_0_imports(graph):
-    RDF_BASE = URIRef("https://spdx.org/rdf/3.0.0/terms/")
+    """Get imported SPDX IDs from an SPDX 3.0.0 graph."""
+    RDF_BASE = URIRef("https://spdx.org/rdf/3.0.0/terms/")  # pylint: disable=invalid-name
 
     for doc in graph.subjects(RDF.type, RDF_BASE + "Core/SpdxDocument"):
         for i in graph.objects(doc, RDF_BASE + "Core/imports"):
-            for spdxid in graph.objects(i, RDF_BASE + "Core/externalSpdxId"):
-                yield spdxid
+            yield from graph.objects(i, RDF_BASE + "Core/externalSpdxId")
 
 
 def get_3_0_1_imports(graph):
-    RDF_BASE = URIRef("https://spdx.org/rdf/3.0.1/terms/")
+    """Get imported SPDX IDs from an SPDX 3.0.1 graph."""
+    RDF_BASE = URIRef("https://spdx.org/rdf/3.0.1/terms/")  # pylint: disable=invalid-name
 
     for doc in graph.subjects(RDF.type, RDF_BASE + "Core/SpdxDocument"):
         for i in graph.objects(doc, RDF_BASE + "Core/import"):
-            for spdxid in graph.objects(i, RDF_BASE + "Core/externalSpdxId"):
-                yield spdxid
+            yield from graph.objects(i, RDF_BASE + "Core/externalSpdxId")
 
 
 SPDX_VERSIONS = (
@@ -52,6 +53,7 @@ SPDX_VERSIONS = (
 
 
 def find_version(context_url):
+    """Find an SPDX version by its context URL."""
     for s in SPDX_VERSIONS:
         if s.context_url == context_url:
             return s

--- a/src/spdx3_validate/version.py
+++ b/src/spdx3_validate/version.py
@@ -1,1 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 Joshua Watt
+# SPDX-License-Identifier: MIT
+
+"""Library version information."""
+
 VERSION = "0.0.5"


### PR DESCRIPTION
- Remove nonlocal declarations in main.py lines 80-84, these variables are accessed inside the scope but never been assigned, so 'nonlocal' declarations are unnecessary (flagged by flake8 as "name is never assigned in scope" - https://github.com/JPEWdev/spdx3-validate/actions/runs/19065698022/job/54455665884?pr=3#step:5:41 )
- Use 'err' instead of 'e' in main.py lines 314-315, 319-320, 325-327, 337-338, 343-345, to avoid complains about assigning 'e' outside exception block (flagged by mypy)
- Sort import & add docstrings