### PR TITLE
Refactor for library

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,10 +18,10 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.x'
 
@@ -34,4 +34,4 @@ jobs:
         run: python -m build
 
       - name: Publish distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,7 +33,7 @@ jobs:
           python -m build
       - name: Install package
         run: |
-          pip install -e .[dev]
+          pip install -e ".[dev]"
       - name: Run tests
         run: |
           pytest -v
@@ -47,3 +47,10 @@ jobs:
           python-version: "3.11"
       - uses: psf/black@87928e6d6761a4a6d22250e1fee5601b3998086e # 26.5.1
       - uses: py-actions/flake8@84ec6726560b6d5bd68f2a5bed83d62b52bb50ba # v2.3.0
+      - name: Install mypy
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+      - name: Run mypy
+        run: |
+          mypy

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,10 +16,12 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
+          - "3.14"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -32,16 +34,16 @@ jobs:
       - name: Install package
         run: |
           pip install -e .[dev]
-      #- name: Run tests
-      #  run: |
-      #    pytest -v
+      - name: Run tests
+        run: |
+          pytest -v
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.11"
-      - uses: psf/black@stable
-      - uses: py-actions/flake8@v2
+      - uses: psf/black@87928e6d6761a4a6d22250e1fee5601b3998086e # 26.5.1
+      - uses: py-actions/flake8@84ec6726560b6d5bd68f2a5bed83d62b52bb50ba # v2.3.0

--- a/README.md
+++ b/README.md
@@ -23,6 +23,31 @@ useful. This includes:
 python3 -m pip install spdx3-validate
 ```
 
+## Using as a library
+
+`spdx3-validate` can also be used programmatically.
+`validate()` takes a single source or an iterable of sources
+(a path, a URL, or `"-"` for standard input) and returns a `ValidationResult`:
+
+```python
+import spdx3_validate
+
+result = spdx3_validate.validate("doc.spdx3.json")
+if not result:
+    print(result)  # prints the errors, one per line
+
+# Or inspect the individual findings:
+for error in result.errors:
+    print(error)
+```
+
+- The SPDX version is detected from each document's `@context`;
+  pass `version="3.0.1"` to force one.
+- Set `check_merged=True` to also validate the merged graph of several
+  documents together.
+- A document that cannot be loaded (missing `@context`, unknown version,
+  incompatible versions) raises `spdx3_validate.SpdxValidateError`.
+
 ## Developing
 
 Developing on `spdx3-validate` is best done using a virtual environment. You

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ python3 -m pip install spdx3-validate
 
 `spdx3-validate` can also be used programmatically.
 `validate()` takes a single source or an iterable of sources
-(a path, a URL, or `"-"` for standard input) and returns a `ValidationResult`:
+(a path or a URL) and returns a `ValidationResult`:
 
 ```python
 import spdx3_validate
@@ -42,7 +42,7 @@ for error in result.errors:
 ```
 
 - The SPDX version is detected from each document's `@context`;
-  pass `version="3.0.1"` to force one.
+  pass `version="X.Y"` to force one.
 - Set `check_merged=True` to also validate the merged graph of several
   documents together.
 - A document that cannot be loaded (missing `@context`, unknown version,
@@ -62,5 +62,6 @@ pip install -e ".[dev]"
 
 ## TODO
 
-* Option to automatically download dependencies based on `locationHint`
-* Offline validation?
+- Option to automatically download dependencies based on `locationHint`
+- Offline validation?
+- Cache downloaded context

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,9 +49,10 @@ build-backend = "hatchling.build"
 path = "src/spdx3_validate/version.py"
 
 [tool.pytest.ini_options]
+testpaths = ["tests"]
 addopts = [
     "--import-mode=importlib",
-    "--cov=shacl2code",
+    "--cov=spdx3_validate",
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,9 @@ addopts = [
 relative_files = true
 
 [tool.mypy]
-python_version = "3.8"
+# This for mypy's target, not requires-python
+# mypy minimum supported version is 3.10
+python_version = "3.10"
 files = ["src"]
 strict = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ Repository = "https://github.com/JPEWdev/spdx3-validate.git"
 Issues = "https://github.com/JPEWdev/spdx3-validate/issues"
 
 [project.scripts]
-spdx3-validate = "spdx3_validate:main"
+spdx3-validate = "spdx3_validate.main:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,10 @@ classifiers = [
 [project.optional-dependencies]
 dev = [
     "flake8 >= 7.0.0",
+    "mypy >= 1.11",
     "pytest >= 7.4",
     "pytest-cov >= 4.1",
+    "types-jsonschema >= 4.21",
 ]
 
 [project.urls]
@@ -59,3 +61,12 @@ addopts = [
 
 [tool.coverage.run]
 relative_files = true
+
+[tool.mypy]
+python_version = "3.8"
+files = ["src"]
+strict = true
+
+[[tool.mypy.overrides]]
+module = ["halo.*"]
+ignore_missing_imports = true

--- a/src/spdx3_validate/__init__.py
+++ b/src/spdx3_validate/__init__.py
@@ -1,1 +1,27 @@
-from .main import main  # noqa: F401
+# SPDX-FileContributor: Joshua Watt
+# SPDX-FileCopyrightText: 2024 Joshua Watt
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: MIT
+"""spdx3-validate: SPDX 3 validation library and CLI tool."""
+
+from .core import (
+    Document,
+    SpdxValidateError,
+    UnknownVersionError,
+    ValidationError,
+    ValidationResult,
+    validate,
+)
+from .main import spdx3validate
+from .version import VERSION as __version__
+
+__all__ = [
+    "__version__",
+    "validate",
+    "ValidationResult",
+    "ValidationError",
+    "Document",
+    "SpdxValidateError",
+    "UnknownVersionError",
+    "spdx3validate",
+]

--- a/src/spdx3_validate/__main__.py
+++ b/src/spdx3_validate/__main__.py
@@ -1,7 +1,8 @@
 # /usr/bin/env python3
 #
-# Copyright (c) 2024 Joshua Watt
-#
+# SPDX-FileContributor: Joshua Watt
+# SPDX-FileCopyrightText: 2024 Joshua Watt
+# SPDX-FileType: SOURCE
 # SPDX-License-Identifier: MIT
 from .main import main
 

--- a/src/spdx3_validate/core.py
+++ b/src/spdx3_validate/core.py
@@ -1,0 +1,137 @@
+# SPDX-FileContributor: Joshua Watt
+# SPDX-FileCopyrightText: 2026 Joshua Watt
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: MIT
+
+import sys
+import textwrap
+import urllib.request
+
+from pathlib import Path
+
+import pyshacl
+import rdflib
+
+from rdflib import RDF, RDFS, SH, URIRef
+
+
+def read_location(location):
+    if "://" in location:
+        with urllib.request.urlopen(location) as f:
+            return f.read()
+    elif location == "-":
+        return sys.stdin.read()
+    else:
+        with Path(location).open("r") as f:
+            return f.read()
+
+
+def derives_from(cls, target, shacl_graph):
+    if cls == target:
+        return True
+
+    for subclass in shacl_graph.objects(cls, RDFS.subClassOf):
+        if derives_from(subclass, target, shacl_graph):
+            return True
+
+    return False
+
+
+def check_graph(graph, shacl_graph, current_version, error_external):
+    errors = []
+
+    conforms, results, _ = pyshacl.validate(
+        graph,
+        shacl_graph=shacl_graph,
+        ont_graph=shacl_graph,
+    )
+
+    if not conforms:
+        results.bind("sh", SH)
+        nm = rdflib.namespace.NamespaceManager(results)
+
+        def norm(uri):
+            return nm.normalizeUri(uri)
+
+        def pnode(n):
+            if n:
+                return n.n3()
+            return "-"
+
+        # Collect all external map references
+        external_spdxids = set()
+        for spdxid in current_version.get_imports(graph):
+            # If the SpdxID is in the graph as a subject, than do
+            # not mark it as an external SpdxID, since there is a
+            # resolved definition for it
+            if (spdxid, None, None) in graph:
+                if error_external:
+                    errors.append(
+                        f"ERROR: {str(spdxid)} in an ExternalMap and also defined in the document"
+                    )
+            else:
+                external_spdxids.add(str(spdxid))
+
+        def check_external_ref_error(r):
+            if (r, RDF.type, SH.ValidationResult) not in results:
+                return False
+
+            if (r, SH.resultSeverity, SH.Violation) not in results:
+                return False
+
+            if (
+                r,
+                SH.sourceConstraintComponent,
+                SH.ClassConstraintComponent,
+            ) not in results:
+                return False
+
+            is_element = False
+            for ss in results.objects(r, SH.sourceShape):
+                if is_element:
+                    break
+
+                for cls in results.objects(ss, SH["class"]):
+                    is_element = derives_from(
+                        cls,
+                        URIRef(current_version.rdf_base + "Core/Element"),
+                        shacl_graph,
+                    )
+                    if is_element:
+                        break
+
+            if not is_element:
+                return False
+
+            for v in results.objects(r, SH.value):
+                if str(v) in external_spdxids:
+                    return True
+
+            return False
+
+        for report in results.subjects(RDF.type, SH.ValidationReport):
+            for r in results.objects(report, SH.result):
+                if check_external_ref_error(r):
+                    continue
+
+                e = []
+                e.append(
+                    f"Violation of type {norm(results.value(r, SH.sourceConstraintComponent))}:"
+                )
+                e.append(f"\tSeverity: {norm(results.value(r, SH.resultSeverity))}")
+                pg = rdflib.Graph()
+                pg += results.triples((results.value(r, SH.sourceShape), None, None))
+                if pg:
+                    e.append("\tSource Shape:")
+                    e.append(
+                        textwrap.indent(pg.serialize(format="ttl").strip(), "\t\t")
+                    )
+                e.append(f"\tFocus Node: {pnode(results.value(r, SH.focusNode))}")
+                e.append(f"\tValue Node: {pnode(results.value(r, SH.value))}")
+                e.append(f"\tResult path: {pnode(results.value(r, SH.resultPath))}")
+                e.append(f"\tMessage: {results.value(r, SH.resultMessage) or '-'}")
+                e.append("")
+
+                errors.append("\n".join(e))
+
+    return errors

--- a/src/spdx3_validate/core.py
+++ b/src/spdx3_validate/core.py
@@ -1,32 +1,165 @@
 # SPDX-FileContributor: Joshua Watt
+# SPDX-FileContributor: Arthit Suriyawongkul
 # SPDX-FileCopyrightText: 2026 Joshua Watt
 # SPDX-FileType: SOURCE
 # SPDX-License-Identifier: MIT
 
+"""Core SPDX 3 validation engine.
+
+This module is the library heart of ``spdx3-validate``. It performs no console
+output: loading problems are raised as :class:`SpdxValidateError`, and the
+validation findings themselves are returned as data. The command-line interface
+in :mod:`spdx3_validate.main` builds its progress spinners and error printing on
+top of these primitives.
+"""
+
+import json
 import sys
 import textwrap
 import urllib.request
-
+from dataclasses import dataclass, field
 from pathlib import Path
 
+import jsonschema
 import pyshacl
 import rdflib
-
 from rdflib import RDF, RDFS, SH, URIRef
+
+from .spdx_versions import SPDX_VERSIONS, SpdxVersion, find_version
+
+
+class SpdxValidateError(Exception):
+    """Base class for errors raised while loading or validating documents."""
+
+
+class UnknownVersionError(SpdxValidateError):
+    """The requested SPDX version, or a document's ``@context``, is unknown."""
+
+
+@dataclass
+class ValidationError:
+    """A single validation finding, attributed to the document it came from.
+
+    Attributes:
+        source: The document the error was found in (path, URL, or ``"-"``).
+            For a merged-graph check this is ``"(merged)"``.
+        kind: ``"schema"`` for JSON Schema errors, ``"shacl"`` for SHACL ones.
+        message: The human-readable description of the problem.
+    """
+
+    source: str
+    kind: str
+    message: str
+
+    def __str__(self):
+        return f"{self.source} [{self.kind}]: {self.message}"
+
+
+def _resolve_version(version):
+    """Normalise a version argument to a :class:`SpdxVersion` or ``None``.
+
+    Accepts ``None`` (auto-detect from the documents), a :class:`SpdxVersion`,
+    or a version string such as ``"3.0.1"``.
+    """
+    if version is None or isinstance(version, SpdxVersion):
+        return version
+
+    for v in SPDX_VERSIONS:
+        if v.pretty == version:
+            return v
+
+    raise UnknownVersionError(f"Unknown SPDX version {version}")
 
 
 def read_location(location):
+    """Read the contents of a path, an URL, or ``"-"`` for standard input."""
     if "://" in location:
         with urllib.request.urlopen(location) as f:
             return f.read()
-    elif location == "-":
+    if location == "-":
         return sys.stdin.read()
+    with Path(location).open("r") as f:
+        return f.read()
+
+
+@dataclass
+class Document:
+    """An SPDX 3 document loaded from a source location.
+
+    Attributes:
+        source: Where the document was loaded from (path, URL, or ``"-"``).
+        data: The parsed JSON content.
+        graph: The document parsed as an RDF graph.
+        version: The SPDX version detected from the document's ``@context``.
+    """
+
+    source: str
+    data: dict
+    graph: rdflib.Graph
+    version: SpdxVersion
+
+    @classmethod
+    def load(cls, source):
+        """Load and parse an SPDX 3 document from a path, URL, or ``"-"``.
+
+        Raises:
+            SpdxValidateError: The document has no ``@context``.
+            UnknownVersionError: The ``@context`` is not a known SPDX version.
+        """
+        text = read_location(source)
+        data = json.loads(text)
+
+        if "@context" not in data:
+            raise SpdxValidateError(f"No @context found in {source}")
+
+        version = find_version(data["@context"])
+        if version is None:
+            raise UnknownVersionError(
+                f"{source} has unknown version @context {data['@context']}"
+            )
+
+        graph = rdflib.Graph()
+        graph.parse(data=text, format="json-ld")
+
+        return cls(source, data, graph, version)
+
+
+def load_validation_data(version):
+    """Download the JSON Schema and SHACL model for an SPDX *version*.
+
+    Returns a ``(schema, shacl_graph)`` tuple.
+    """
+    with urllib.request.urlopen(version.schema_url) as f:
+        schema = json.load(f)
+
+    shacl_graph = rdflib.Graph()
+    shacl_graph.parse(version.shacl_url)
+
+    return schema, shacl_graph
+
+
+def schema_validator(schema):
+    """Return a ``jsonschema`` validator, checking that *schema* is well formed.
+
+    Raises:
+        jsonschema.exceptions.SchemaError: The schema itself is invalid.
+    """
+    validator_cls = jsonschema.validators.validator_for(schema)
+    validator_cls.check_schema(schema)
+    return validator_cls(schema)
+
+
+def _schema_error(source, err):
+    """Build a :class:`ValidationError` from a ``jsonschema`` error."""
+    if isinstance(err.instance, str):
+        message = err.message
     else:
-        with Path(location).open("r") as f:
-            return f.read()
+        message = "Is not valid"
+    return ValidationError(source, "schema", f"{err.json_path}: {message}")
 
 
 def derives_from(cls, target, shacl_graph):
+    """Return True if RDF class *cls* is, or derives from, *target*."""
     if cls == target:
         return True
 
@@ -38,6 +171,12 @@ def derives_from(cls, target, shacl_graph):
 
 
 def check_graph(graph, shacl_graph, current_version, error_external):
+    """Validate *graph* against *shacl_graph*, returning a list of error strings.
+
+    External ``spdxId`` references declared in an ``ExternalMap`` are not
+    reported as missing. When *error_external* is true, an ``spdxId`` that is
+    both imported and defined in the document is reported as an error.
+    """
     errors = []
 
     conforms, results, _ = pyshacl.validate(
@@ -135,3 +274,99 @@ def check_graph(graph, shacl_graph, current_version, error_external):
                 errors.append("\n".join(e))
 
     return errors
+
+
+@dataclass
+class ValidationResult:
+    """The outcome of validating one or more SPDX 3 documents.
+
+    ``errors`` is a list of :class:`ValidationError`. A result is truthy when
+    validation passed, so it reads naturally::
+
+        result = validate("sbom.json")
+        if not result:
+            print(result)  # prints the errors, one per line
+    """
+
+    errors: list = field(default_factory=list)
+
+    @property
+    def valid(self):
+        """True when no validation errors were found."""
+        return not self.errors
+
+    def __bool__(self):
+        return self.valid
+
+    def __str__(self):
+        return "\n".join(self.errors)
+
+
+def validate(sources, *, version=None, check_merged=False):
+    """Validate one or more SPDX 3 documents against schema and SHACL rules.
+
+    Args:
+        sources: A single path/URL/``"-"``, or an iterable of them.
+        version: SPDX version to validate against (e.g. ``"3.0.1"``). When
+            ``None`` (the default) the version is detected from each document's
+            ``@context``.
+        check_merged: Also validate the graph formed by merging every document,
+            which catches type errors across ``ExternalMap`` references. Skipped
+            if any document already failed.
+
+    Returns:
+        ValidationResult: The collected :class:`ValidationError` findings
+            (empty when everything is valid).
+
+    Raises:
+        SpdxValidateError: A document cannot be loaded, or documents declare
+            incompatible versions.
+        UnknownVersionError: *version* or a document ``@context`` is unknown.
+    """
+    if isinstance(sources, str):
+        sources = [sources]
+
+    version = _resolve_version(version)
+
+    documents = []
+    for source in sources:
+        doc = Document.load(source)
+        if version is None:
+            version = doc.version
+        elif doc.version != version:
+            raise SpdxValidateError(
+                f"{source} has incompatible version {doc.version.pretty}. "
+                f"Other documents are {version.pretty}"
+            )
+        documents.append(doc)
+
+    if not documents:
+        return ValidationResult()
+
+    schema, shacl_graph = load_validation_data(version)
+
+    try:
+        validator = schema_validator(schema)
+    except jsonschema.exceptions.SchemaError as e:
+        raise SpdxValidateError(f"Invalid schema {version.schema_url}: {e}") from e
+
+    errors = []
+    for doc in documents:
+        errors.extend(
+            _schema_error(doc.source, e) for e in validator.iter_errors(doc.data)
+        )
+        errors.extend(
+            ValidationError(doc.source, "shacl", msg)
+            for msg in check_graph(doc.graph, shacl_graph, version, True)
+        )
+
+    if len(documents) > 1 and check_merged and not errors:
+        merged = rdflib.Graph()
+        for doc in documents:
+            merged += doc.graph
+        errors.extend(
+            ValidationError("(merged)", "shacl", msg)
+            for msg in check_graph(merged, shacl_graph, version, False)
+        )
+
+    return ValidationResult(errors)

--- a/src/spdx3_validate/core.py
+++ b/src/spdx3_validate/core.py
@@ -13,16 +13,20 @@ in :mod:`spdx3_validate.main` builds its progress spinners and error printing on
 top of these primitives.
 """
 
+from __future__ import annotations
+
 import json
 import textwrap
 import urllib.request
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union, cast
 
 import jsonschema
 import pyshacl
 import rdflib
 from rdflib import RDF, RDFS, SH, URIRef
+from rdflib.term import Node
 
 from .spdx_versions import SPDX_VERSIONS, SpdxVersion, find_version
 
@@ -50,11 +54,13 @@ class ValidationError:
     kind: str
     message: str
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.source} [{self.kind}]: {self.message}"
 
 
-def _resolve_version(version):
+def _resolve_version(
+    version: Union[str, SpdxVersion, None],
+) -> Optional[SpdxVersion]:
     """Normalise a version argument to a :class:`SpdxVersion` or ``None``.
 
     Accepts ``None`` (auto-detect from the documents), a :class:`SpdxVersion`,
@@ -70,11 +76,12 @@ def _resolve_version(version):
     raise UnknownVersionError(f"Unknown SPDX version {version}")
 
 
-def read_location(location):
+def read_location(location: str) -> str:
     """Read the contents of a path or an URL."""
     if "://" in location:
         with urllib.request.urlopen(location) as f:
-            return f.read()
+            content: bytes = f.read()
+            return content.decode("utf-8")
     with Path(location).open("r", encoding="utf-8") as f:
         return f.read()
 
@@ -93,12 +100,12 @@ class Document:
     """
 
     source: str
-    data: dict
+    data: Dict[str, Any]
     graph: rdflib.Graph
     version: SpdxVersion
 
     @classmethod
-    def load(cls, source):
+    def load(cls, source: str) -> Document:
         """Load and parse an SPDX 3 document from a path or URL.
 
         Raises:
@@ -108,7 +115,7 @@ class Document:
         return cls.from_text(source, read_location(source))
 
     @classmethod
-    def from_text(cls, source, text):
+    def from_text(cls, source: str, text: str) -> Document:
         """Parse an SPDX 3 document already held in memory.
 
         Args:
@@ -137,7 +144,7 @@ class Document:
         return cls(source, data, graph, version)
 
 
-def load_validation_data(version):
+def load_validation_data(version: SpdxVersion) -> Tuple[Dict[str, Any], rdflib.Graph]:
     """Download the JSON Schema and SHACL model for an SPDX *version*.
 
     Returns a ``(schema, shacl_graph)`` tuple.
@@ -151,7 +158,7 @@ def load_validation_data(version):
     return schema, shacl_graph
 
 
-def schema_validator(schema):
+def schema_validator(schema: Dict[str, Any]) -> jsonschema.protocols.Validator:
     """Return a ``jsonschema`` validator, checking that *schema* is well formed.
 
     Raises:
@@ -159,10 +166,12 @@ def schema_validator(schema):
     """
     validator_cls = jsonschema.validators.validator_for(schema)
     validator_cls.check_schema(schema)
-    return validator_cls(schema)
+    return cast(jsonschema.protocols.Validator, validator_cls(schema))
 
 
-def _schema_error(source, err):
+def _schema_error(
+    source: str, err: jsonschema.exceptions.ValidationError
+) -> ValidationError:
     """Build a :class:`ValidationError` from a ``jsonschema`` error."""
     if isinstance(err.instance, str):
         message = err.message
@@ -171,7 +180,7 @@ def _schema_error(source, err):
     return ValidationError(source, "schema", f"{err.json_path}: {message}")
 
 
-def derives_from(cls, target, shacl_graph):
+def derives_from(cls: Node, target: Node, shacl_graph: rdflib.Graph) -> bool:
     """Return True if RDF class *cls* is, or derives from, *target*."""
     if cls == target:
         return True
@@ -183,35 +192,47 @@ def derives_from(cls, target, shacl_graph):
     return False
 
 
-def check_graph(graph, shacl_graph, current_version, error_external):
+def check_graph(
+    graph: rdflib.Graph,
+    shacl_graph: rdflib.Graph,
+    current_version: SpdxVersion,
+    error_external: bool,
+) -> List[str]:
     """Validate *graph* against *shacl_graph*, returning a list of error strings.
 
     External ``spdxId`` references declared in an ``ExternalMap`` are not
     reported as missing. When *error_external* is true, an ``spdxId`` that is
     both imported and defined in the document is reported as an error.
     """
-    errors = []
+    errors: List[str] = []
 
-    conforms, results, _ = pyshacl.validate(
-        graph,
-        shacl_graph=shacl_graph,
-        ont_graph=shacl_graph,
+    # pyshacl.validate() has no return type annotation, so its result is
+    # cast here to restore type checking for the rest of this function.
+    validate_result = cast(
+        Tuple[bool, rdflib.Graph, str],
+        pyshacl.validate(
+            graph,
+            shacl_graph=shacl_graph,
+            ont_graph=shacl_graph,
+        ),
     )
+    conforms, results, _ = validate_result
 
     if not conforms:
         results.bind("sh", SH)
         nm = rdflib.namespace.NamespaceManager(results)
 
-        def norm(uri):
-            return nm.normalizeUri(uri)
+        def norm(uri: Optional[Node]) -> str:
+            assert uri is not None
+            return nm.normalizeUri(str(uri))
 
-        def pnode(n):
+        def pnode(n: Optional[Node]) -> str:
             if n:
                 return n.n3()
             return "-"
 
         # Collect all external map references
-        external_spdxids = set()
+        external_spdxids: set[str] = set()
         for spdxid in current_version.get_imports(graph):
             # If the SpdxID is in the graph as a subject, than do
             # not mark it as an external SpdxID, since there is a
@@ -224,7 +245,7 @@ def check_graph(graph, shacl_graph, current_version, error_external):
             else:
                 external_spdxids.add(str(spdxid))
 
-        def check_external_ref_error(r):
+        def check_external_ref_error(r: Node) -> bool:
             if (r, RDF.type, SH.ValidationResult) not in results:
                 return False
 
@@ -266,7 +287,7 @@ def check_graph(graph, shacl_graph, current_version, error_external):
                 if check_external_ref_error(r):
                     continue
 
-                e = []
+                e: List[str] = []
                 e.append(
                     f"Violation of type {norm(results.value(r, SH.sourceConstraintComponent))}:"
                 )
@@ -301,21 +322,26 @@ class ValidationResult:
             print(result)  # prints the errors, one per line
     """
 
-    errors: list = field(default_factory=list)
+    errors: List[ValidationError] = field(default_factory=list)
 
     @property
-    def valid(self):
+    def valid(self) -> bool:
         """True when no validation errors were found."""
         return not self.errors
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         return self.valid
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "\n".join(str(e) for e in self.errors)
 
 
-def validate(sources, *, version=None, check_merged=False):
+def validate(
+    sources: Union[str, Iterable[str]],
+    *,
+    version: Union[str, SpdxVersion, None] = None,
+    check_merged: bool = False,
+) -> ValidationResult:
     """Validate one or more SPDX 3 documents against schema and SHACL rules.
 
     Args:
@@ -339,38 +365,43 @@ def validate(sources, *, version=None, check_merged=False):
     if isinstance(sources, str):
         sources = [sources]
 
-    version = _resolve_version(version)
+    resolved_version = _resolve_version(version)
 
-    documents = []
+    documents: List[Document] = []
     for source in sources:
         doc = Document.load(source)
-        if version is None:
-            version = doc.version
-        elif doc.version != version:
+        if resolved_version is None:
+            resolved_version = doc.version
+        elif doc.version != resolved_version:
             raise SpdxValidateError(
                 f"{source} has incompatible version {doc.version.pretty}. "
-                f"Other documents are {version.pretty}"
+                f"Other documents are {resolved_version.pretty}"
             )
         documents.append(doc)
 
     if not documents:
         return ValidationResult()
 
-    schema, shacl_graph = load_validation_data(version)
+    # documents is non-empty, so the loop above set resolved_version at least once.
+    assert resolved_version is not None
+
+    schema, shacl_graph = load_validation_data(resolved_version)
 
     try:
         validator = schema_validator(schema)
     except jsonschema.exceptions.SchemaError as e:
-        raise SpdxValidateError(f"Invalid schema {version.schema_url}: {e}") from e
+        raise SpdxValidateError(
+            f"Invalid schema {resolved_version.schema_url}: {e}"
+        ) from e
 
-    errors = []
+    errors: List[ValidationError] = []
     for doc in documents:
         errors.extend(
             _schema_error(doc.source, e) for e in validator.iter_errors(doc.data)
         )
         errors.extend(
             ValidationError(doc.source, "shacl", msg)
-            for msg in check_graph(doc.graph, shacl_graph, version, True)
+            for msg in check_graph(doc.graph, shacl_graph, resolved_version, True)
         )
 
     if len(documents) > 1 and check_merged and not errors:
@@ -379,7 +410,7 @@ def validate(sources, *, version=None, check_merged=False):
             merged += doc.graph
         errors.extend(
             ValidationError("(merged)", "shacl", msg)
-            for msg in check_graph(merged, shacl_graph, version, False)
+            for msg in check_graph(merged, shacl_graph, resolved_version, False)
         )
 
     return ValidationResult(errors)

--- a/src/spdx3_validate/core.py
+++ b/src/spdx3_validate/core.py
@@ -299,7 +299,7 @@ class ValidationResult:
         return self.valid
 
     def __str__(self):
-        return "\n".join(self.errors)
+        return "\n".join(str(e) for e in self.errors)
 
 
 def validate(sources, *, version=None, check_merged=False):

--- a/src/spdx3_validate/core.py
+++ b/src/spdx3_validate/core.py
@@ -75,7 +75,7 @@ def read_location(location):
     if "://" in location:
         with urllib.request.urlopen(location) as f:
             return f.read()
-    with Path(location).open("r") as f:
+    with Path(location).open("r", encoding="utf-8") as f:
         return f.read()
 
 

--- a/src/spdx3_validate/core.py
+++ b/src/spdx3_validate/core.py
@@ -20,7 +20,7 @@ import textwrap
 import urllib.request
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Union, cast
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 import jsonschema
 import pyshacl
@@ -166,7 +166,11 @@ def schema_validator(schema: Dict[str, Any]) -> jsonschema.protocols.Validator:
     """
     validator_cls = jsonschema.validators.validator_for(schema)
     validator_cls.check_schema(schema)
-    return cast(jsonschema.protocols.Validator, validator_cls(schema))
+    # validator_for()'s return type varies with the jsonschema/types-jsonschema
+    # version resolved, so assign through an annotation instead of cast() --
+    # cast() is flagged "redundant" in environments where this is already typed.
+    validator: jsonschema.protocols.Validator = validator_cls(schema)
+    return validator
 
 
 def _schema_error(
@@ -207,14 +211,12 @@ def check_graph(
     errors: List[str] = []
 
     # pyshacl.validate() has no return type annotation, so its result is
-    # cast here to restore type checking for the rest of this function.
-    validate_result = cast(
-        Tuple[bool, rdflib.Graph, str],
-        pyshacl.validate(
-            graph,
-            shacl_graph=shacl_graph,
-            ont_graph=shacl_graph,
-        ),
+    # typed here via annotation to restore type checking for the rest of
+    # this function.
+    validate_result: Tuple[bool, rdflib.Graph, str] = pyshacl.validate(
+        graph,
+        shacl_graph=shacl_graph,
+        ont_graph=shacl_graph,
     )
     conforms, results, _ = validate_result
 

--- a/src/spdx3_validate/core.py
+++ b/src/spdx3_validate/core.py
@@ -14,7 +14,6 @@ top of these primitives.
 """
 
 import json
-import sys
 import textwrap
 import urllib.request
 from dataclasses import dataclass, field
@@ -41,7 +40,7 @@ class ValidationError:
     """A single validation finding, attributed to the document it came from.
 
     Attributes:
-        source: The document the error was found in (path, URL, or ``"-"``).
+        source: The document the error was found in (its :attr:`Document.source`).
             For a merged-graph check this is ``"(merged)"``.
         kind: ``"schema"`` for JSON Schema errors, ``"shacl"`` for SHACL ones.
         message: The human-readable description of the problem.
@@ -72,12 +71,10 @@ def _resolve_version(version):
 
 
 def read_location(location):
-    """Read the contents of a path, an URL, or ``"-"`` for standard input."""
+    """Read the contents of a path or an URL."""
     if "://" in location:
         with urllib.request.urlopen(location) as f:
             return f.read()
-    if location == "-":
-        return sys.stdin.read()
     with Path(location).open("r") as f:
         return f.read()
 
@@ -87,7 +84,9 @@ class Document:
     """An SPDX 3 document loaded from a source location.
 
     Attributes:
-        source: Where the document was loaded from (path, URL, or ``"-"``).
+        source: Where the document came from. A path or URL for documents
+            loaded with :meth:`load`, or any caller-supplied label for
+            documents built with :meth:`from_text`.
         data: The parsed JSON content.
         graph: The document parsed as an RDF graph.
         version: The SPDX version detected from the document's ``@context``.
@@ -100,13 +99,27 @@ class Document:
 
     @classmethod
     def load(cls, source):
-        """Load and parse an SPDX 3 document from a path, URL, or ``"-"``.
+        """Load and parse an SPDX 3 document from a path or URL.
 
         Raises:
             SpdxValidateError: The document has no ``@context``.
             UnknownVersionError: The ``@context`` is not a known SPDX version.
         """
-        text = read_location(source)
+        return cls.from_text(source, read_location(source))
+
+    @classmethod
+    def from_text(cls, source, text):
+        """Parse an SPDX 3 document already held in memory.
+
+        Args:
+            source: A label identifying the document (e.g. a filename), used
+                only to attribute errors to it.
+            text: The raw JSON-LD document content.
+
+        Raises:
+            SpdxValidateError: The document has no ``@context``.
+            UnknownVersionError: The ``@context`` is not a known SPDX version.
+        """
         data = json.loads(text)
 
         if "@context" not in data:
@@ -306,7 +319,7 @@ def validate(sources, *, version=None, check_merged=False):
     """Validate one or more SPDX 3 documents against schema and SHACL rules.
 
     Args:
-        sources: A single path/URL/``"-"``, or an iterable of them.
+        sources: A single path or URL, or an iterable of them.
         version: SPDX version to validate against (e.g. ``"3.0.1"``). When
             ``None`` (the default) the version is detected from each document's
             ``@context``.

--- a/src/spdx3_validate/main.py
+++ b/src/spdx3_validate/main.py
@@ -1,144 +1,18 @@
-# Copyright (c) 2024 Joshua Watt
-#
+# SPDX-FileContributor: Joshua Watt
+# SPDX-FileCopyrightText: 2024 Joshua Watt
+# SPDX-FileType: SOURCE
 # SPDX-License-Identifier: MIT
 
 import argparse
 import halo
 import json
 import jsonschema
-import pyshacl
 import rdflib
-import sys
-import textwrap
 import urllib.request
 
-from rdflib import RDF, RDFS, SH, URIRef
-
-from pathlib import Path
 from .version import VERSION
 from .spdx_versions import find_version, SPDX_VERSIONS
-
-
-def read_location(location):
-    if "://" in location:
-        with urllib.request.urlopen(location) as f:
-            return f.read()
-    elif location == "-":
-        return sys.stdin.read()
-    else:
-        with Path(location).open("r") as f:
-            return f.read()
-
-
-def derives_from(cls, target, shacl_graph):
-    if cls == target:
-        return True
-
-    for subclass in shacl_graph.objects(cls, RDFS.subClassOf):
-        if derives_from(subclass, target, shacl_graph):
-            return True
-
-    return False
-
-
-def check_graph(graph, shacl_graph, current_version, error_external):
-    errors = []
-
-    conforms, results, _ = pyshacl.validate(
-        graph,
-        shacl_graph=shacl_graph,
-        ont_graph=shacl_graph,
-    )
-
-    if not conforms:
-        results.bind("sh", SH)
-        nm = rdflib.namespace.NamespaceManager(results)
-
-        def norm(uri):
-            return nm.normalizeUri(uri)
-
-        def pnode(n):
-            if n:
-                return n.n3()
-            return "-"
-
-        # Collect all external map references
-        external_spdxids = set()
-        for spdxid in current_version.get_imports(graph):
-            # If the SpdxID is in the graph as a subject, than do
-            # not mark it as an external SpdxID, since there is a
-            # resolved definition for it
-            if (spdxid, None, None) in graph:
-                if error_external:
-                    errors.append(
-                        f"ERROR: {str(spdxid)} in an ExternalMap and also defined in the document"
-                    )
-            else:
-                external_spdxids.add(str(spdxid))
-
-        def check_external_ref_error(r):
-            if (r, RDF.type, SH.ValidationResult) not in results:
-                return False
-
-            if (r, SH.resultSeverity, SH.Violation) not in results:
-                return False
-
-            if (
-                r,
-                SH.sourceConstraintComponent,
-                SH.ClassConstraintComponent,
-            ) not in results:
-                return False
-
-            is_element = False
-            for ss in results.objects(r, SH.sourceShape):
-                if is_element:
-                    break
-
-                for cls in results.objects(ss, SH["class"]):
-                    is_element = derives_from(
-                        cls,
-                        URIRef(current_version.rdf_base + "Core/Element"),
-                        shacl_graph,
-                    )
-                    if is_element:
-                        break
-
-            if not is_element:
-                return False
-
-            for v in results.objects(r, SH.value):
-                if str(v) in external_spdxids:
-                    return True
-
-            return False
-
-        for report in results.subjects(RDF.type, SH.ValidationReport):
-            for r in results.objects(report, SH.result):
-                if check_external_ref_error(r):
-                    continue
-
-                e = []
-                e.append(
-                    f"Violation of type {norm(results.value(r, SH.sourceConstraintComponent))}:"
-                )
-                e.append(f"\tSeverity: {norm(results.value(r, SH.resultSeverity))}")
-                pg = rdflib.Graph()
-                pg += results.triples((results.value(r, SH.sourceShape), None, None))
-                if pg:
-                    e.append("\tSource Shape:")
-                    e.append(
-                        textwrap.indent(pg.serialize(format="ttl").strip(), "\t\t")
-                    )
-                e.append(f"\tFocus Node: {pnode(results.value(r, SH.focusNode))}")
-                e.append(f"\tValue Node: {pnode(results.value(r, SH.value))}")
-                e.append(f"\tResult path: {pnode(results.value(r, SH.resultPath))}")
-                e.append(f"\tMessage: {results.value(r, SH.resultMessage) or '-'}")
-                e.append("")
-
-                errors.append("\n".join(e))
-
-    return errors
+from .core import check_graph, read_location
 
 
 def iter_validation_errors(err):

--- a/src/spdx3_validate/main.py
+++ b/src/spdx3_validate/main.py
@@ -5,14 +5,20 @@
 
 import argparse
 import halo
-import json
 import jsonschema
 import rdflib
-import urllib.request
 
 from .version import VERSION
-from .spdx_versions import find_version, SPDX_VERSIONS
-from .core import check_graph, read_location
+from .spdx_versions import SPDX_VERSIONS
+from .core import (
+    Document,
+    SpdxValidateError,
+    UnknownVersionError,
+    check_graph,
+    load_validation_data,
+    schema_validator,
+    _resolve_version,
+)
 
 
 def iter_validation_errors(err):
@@ -101,111 +107,98 @@ def main(cmdline_args=None):
     )
     args = parser.parse_args(cmdline_args)
 
-    if args.spdx_version != "auto":
-        for v in SPDX_VERSIONS:
-            if v.pretty == args.version:
-                current_version = v
-                break
-        else:
-            print(f"Unknown SPDX version {args.version}")
-            return 1
-    else:
-        current_version = None
+    try:
+        current_version = _resolve_version(
+            None if args.spdx_version == "auto" else args.spdx_version
+        )
+    except UnknownVersionError as e:
+        print(str(e))
+        return 1
 
     return spdx3validate(args.json, current_version, args.check_merged, args.quiet)
 
 
-def spdx3validate(json_files, current_version="3.0.1", check_merged=False, quiet=True):
-    files = []
+def spdx3validate(json_files, current_version=None, check_merged=False, quiet=True):
+    current_version = _resolve_version(current_version)
+
+    documents = []
     for j in json_files:
         with halo.Halo(f"Loading {j}", enabled=not quiet) as spinner:
-            s = read_location(j)
-            d = json.loads(s)
-            if "@context" not in d:
+            try:
+                doc = Document.load(j)
+            except SpdxValidateError as e:
                 spinner.fail()
-                print(f"No @context found in {j}")
-                return 1
-
-            version = find_version(d["@context"])
-            if version is None:
-                spinner.fail()
-                print(f"{j} has unknown version @context {d['@context']}")
+                print(str(e))
                 return 1
 
             if current_version is None:
-                current_version = version
-            elif current_version != version:
+                current_version = doc.version
+            elif current_version != doc.version:
                 spinner.fail()
                 print(
-                    f"{j} has incompatible version {version.pretty}. Other documents are {current_version.pretty}"
+                    f"{j} has incompatible version {doc.version.pretty}. Other documents are {current_version.pretty}"
                 )
                 return 1
 
-            graph = rdflib.Graph()
-            graph.parse(data=s, format="json-ld")
-
-            files.append((j, d, graph))
+            documents.append(doc)
             spinner.succeed()
 
-    if not files:
+    if not documents:
         # Nothing to do
         return 0
 
     with halo.Halo(
         f"Loading SPDX {current_version.pretty}", enabled=not quiet
     ) as spinner:
-        with urllib.request.urlopen(current_version.schema_url) as f:
-            schema = json.load(f)
-
-        shacl_graph = rdflib.Graph()
-        shacl_graph.parse(current_version.shacl_url)
+        schema, shacl_graph = load_validation_data(current_version)
         spinner.succeed()
 
     errors = 0
 
-    for fn, json_data, g in files:
-        with halo.Halo(f"Validating schema for {fn}", enabled=not quiet) as spinner:
-            validator_cls = jsonschema.validators.validator_for(schema)
-
+    for doc in documents:
+        with halo.Halo(
+            f"Validating schema for {doc.source}", enabled=not quiet
+        ) as spinner:
             try:
-                validator_cls.check_schema(schema)
+                validator = schema_validator(schema)
             except jsonschema.exceptions.SchemaError as e:
                 spinner.fail(f"Invalid schema {current_version.schema_url}: {e}")
                 return 1
 
-            validator = validator_cls(schema)
-            json_errors = list(validator.iter_errors(json_data))
+            json_errors = list(validator.iter_errors(doc.data))
             if json_errors:
                 spinner.fail()
             else:
                 spinner.succeed()
 
         if json_errors:
-            print(f"ERROR: JSON Schema validation failed for {fn}:")
+            print(f"ERROR: JSON Schema validation failed for {doc.source}:")
             for e in json_errors:
-                print_schema_error(e, fn)
+                print_schema_error(e, doc.source)
                 errors += 1
 
-        with halo.Halo(f"Checking SHACL for {fn}", enabled=not quiet) as spinner:
-            e = check_graph(g, shacl_graph, current_version, True)
+        with halo.Halo(
+            f"Checking SHACL for {doc.source}", enabled=not quiet
+        ) as spinner:
+            e = check_graph(doc.graph, shacl_graph, current_version, True)
             if e:
                 spinner.fail()
             else:
                 spinner.succeed()
 
         if e:
-            print(f"ERROR: SHACL Validation failed for {fn}:")
+            print(f"ERROR: SHACL Validation failed for {doc.source}:")
             print("\n".join(e))
             errors += 1
 
-    if len(files) > 1 and check_merged:
+    if len(documents) > 1 and check_merged:
         if not errors:
             with halo.Halo("Checking merged graph", enabled=not quiet) as spinner:
                 merged_g = rdflib.Graph()
-                for _, _, g in files:
-                    merged_g += g
+                for doc in documents:
+                    merged_g += doc.graph
 
-                e = check_graph(g, shacl_graph, current_version, False)
+                e = check_graph(merged_g, shacl_graph, current_version, False)
                 if e:
                     spinner.fail()
                 else:

--- a/src/spdx3_validate/main.py
+++ b/src/spdx3_validate/main.py
@@ -3,15 +3,18 @@
 # SPDX-FileType: SOURCE
 # SPDX-License-Identifier: MIT
 
+from __future__ import annotations
+
 import argparse
 import sys
+from typing import Any, Dict, Iterator, List, Optional, Sequence, Union
 
 import halo
 import jsonschema
 import rdflib
 
 from .version import VERSION
-from .spdx_versions import SPDX_VERSIONS
+from .spdx_versions import SPDX_VERSIONS, SpdxVersion
 from .core import (
     Document,
     SpdxValidateError,
@@ -23,7 +26,7 @@ from .core import (
 )
 
 
-def load_cli_document(source):
+def load_cli_document(source: str) -> Document:
     """Load a document from a path, URL, or ``"-"`` for standard input.
 
     Unlike :meth:`Document.load`, this also accepts ``"-"``, which is a
@@ -34,15 +37,24 @@ def load_cli_document(source):
     return Document.load(source)
 
 
-def iter_validation_errors(err):
+def iter_validation_errors(
+    err: jsonschema.exceptions.ValidationError,
+) -> Iterator[jsonschema.exceptions.ValidationError]:
     if err.context:
         for e in err.context:
             yield e
             yield from iter_validation_errors(e)
 
 
-def print_schema_error(err, filename, indent=0):
-    def print_err(e, indent, fn=None, message=False):
+def print_schema_error(
+    err: jsonschema.exceptions.ValidationError, filename: str, indent: int = 0
+) -> None:
+    def print_err(
+        e: jsonschema.exceptions.ValidationError,
+        indent: int,
+        fn: Optional[str] = None,
+        message: bool = False,
+    ) -> None:
         loc = e.json_path
         if fn:
             loc = f"{fn}::{loc}"
@@ -60,7 +72,7 @@ def print_schema_error(err, filename, indent=0):
         i_str = " " * (indent + 2)
         print(i_str + "This error was caused by other underlying errors:")
 
-        error_map = {}
+        error_map: Dict[Any, jsonschema.exceptions.ValidationError] = {}
         for e in iter_validation_errors(err):
             if isinstance(e, str):
                 error_map[(tuple(e.absolute_path), e.message)] = e
@@ -81,7 +93,7 @@ def print_schema_error(err, filename, indent=0):
     print()
 
 
-def main(cmdline_args=None):
+def main(cmdline_args: Optional[Sequence[str]] = None) -> int:
     parser = argparse.ArgumentParser(
         description=f"Validate SPDX 3 files Version {VERSION}"
     )
@@ -125,14 +137,19 @@ def main(cmdline_args=None):
     return spdx3validate(args.json, current_version, args.check_merged, args.quiet)
 
 
-def spdx3validate(json_files, current_version=None, check_merged=False, quiet=True):
+def spdx3validate(
+    json_files: List[str],
+    current_version: Union[str, SpdxVersion, None] = None,
+    check_merged: bool = False,
+    quiet: bool = True,
+) -> int:
     try:
-        current_version = _resolve_version(current_version)
+        resolved_version = _resolve_version(current_version)
     except UnknownVersionError as e:
         print(str(e))
         return 1
 
-    documents = []
+    documents: List[Document] = []
     for j in json_files:
         with halo.Halo(f"Loading {j}", enabled=not quiet) as spinner:
             try:
@@ -142,12 +159,12 @@ def spdx3validate(json_files, current_version=None, check_merged=False, quiet=Tr
                 print(str(e))
                 return 1
 
-            if current_version is None:
-                current_version = doc.version
-            elif current_version != doc.version:
+            if resolved_version is None:
+                resolved_version = doc.version
+            elif resolved_version != doc.version:
                 spinner.fail()
                 print(
-                    f"{j} has incompatible version {doc.version.pretty}. Other documents are {current_version.pretty}"
+                    f"{j} has incompatible version {doc.version.pretty}. Other documents are {resolved_version.pretty}"
                 )
                 return 1
 
@@ -158,10 +175,13 @@ def spdx3validate(json_files, current_version=None, check_merged=False, quiet=Tr
         # Nothing to do
         return 0
 
+    # documents is non-empty, so the loop above set resolved_version at least once.
+    assert resolved_version is not None
+
     with halo.Halo(
-        f"Loading SPDX {current_version.pretty}", enabled=not quiet
+        f"Loading SPDX {resolved_version.pretty}", enabled=not quiet
     ) as spinner:
-        schema, shacl_graph = load_validation_data(current_version)
+        schema, shacl_graph = load_validation_data(resolved_version)
         spinner.succeed()
 
     errors = 0
@@ -173,7 +193,7 @@ def spdx3validate(json_files, current_version=None, check_merged=False, quiet=Tr
             try:
                 validator = schema_validator(schema)
             except jsonschema.exceptions.SchemaError as e:
-                spinner.fail(f"Invalid schema {current_version.schema_url}: {e}")
+                spinner.fail(f"Invalid schema {resolved_version.schema_url}: {e}")
                 return 1
 
             json_errors = list(validator.iter_errors(doc.data))
@@ -184,22 +204,22 @@ def spdx3validate(json_files, current_version=None, check_merged=False, quiet=Tr
 
         if json_errors:
             print(f"ERROR: JSON Schema validation failed for {doc.source}:")
-            for e in json_errors:
-                print_schema_error(e, doc.source)
+            for json_err in json_errors:
+                print_schema_error(json_err, doc.source)
                 errors += 1
 
         with halo.Halo(
             f"Checking SHACL for {doc.source}", enabled=not quiet
         ) as spinner:
-            e = check_graph(doc.graph, shacl_graph, current_version, True)
-            if e:
+            graph_errors = check_graph(doc.graph, shacl_graph, resolved_version, True)
+            if graph_errors:
                 spinner.fail()
             else:
                 spinner.succeed()
 
-        if e:
+        if graph_errors:
             print(f"ERROR: SHACL Validation failed for {doc.source}:")
-            print("\n".join(e))
+            print("\n".join(graph_errors))
             errors += 1
 
     if len(documents) > 1 and check_merged:
@@ -209,15 +229,17 @@ def spdx3validate(json_files, current_version=None, check_merged=False, quiet=Tr
                 for doc in documents:
                     merged_g += doc.graph
 
-                e = check_graph(merged_g, shacl_graph, current_version, False)
-                if e:
+                graph_errors = check_graph(
+                    merged_g, shacl_graph, resolved_version, False
+                )
+                if graph_errors:
                     spinner.fail()
                 else:
                     spinner.succeed()
 
-            if e:
+            if graph_errors:
                 print("ERROR: SHACL Validation failed on merged files:")
-                print("\n".join(e))
+                print("\n".join(graph_errors))
                 errors += 1
         else:
             print(

--- a/src/spdx3_validate/main.py
+++ b/src/spdx3_validate/main.py
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: MIT
 
 import argparse
+import sys
+
 import halo
 import jsonschema
 import rdflib
@@ -19,6 +21,17 @@ from .core import (
     schema_validator,
     _resolve_version,
 )
+
+
+def load_cli_document(source):
+    """Load a document from a path, URL, or ``"-"`` for standard input.
+
+    Unlike :meth:`Document.load`, this also accepts ``"-"``, which is a
+    command-line convention (not a library one) for reading from stdin.
+    """
+    if source == "-":
+        return Document.from_text(source, sys.stdin.read())
+    return Document.load(source)
 
 
 def iter_validation_errors(err):
@@ -123,7 +136,7 @@ def spdx3validate(json_files, current_version=None, check_merged=False, quiet=Tr
     for j in json_files:
         with halo.Halo(f"Loading {j}", enabled=not quiet) as spinner:
             try:
-                doc = Document.load(j)
+                doc = load_cli_document(j)
             except SpdxValidateError as e:
                 spinner.fail()
                 print(str(e))

--- a/src/spdx3_validate/main.py
+++ b/src/spdx3_validate/main.py
@@ -107,19 +107,17 @@ def main(cmdline_args=None):
     )
     args = parser.parse_args(cmdline_args)
 
-    try:
-        current_version = _resolve_version(
-            None if args.spdx_version == "auto" else args.spdx_version
-        )
-    except UnknownVersionError as e:
-        print(str(e))
-        return 1
+    current_version = None if args.spdx_version == "auto" else args.spdx_version
 
     return spdx3validate(args.json, current_version, args.check_merged, args.quiet)
 
 
 def spdx3validate(json_files, current_version=None, check_merged=False, quiet=True):
-    current_version = _resolve_version(current_version)
+    try:
+        current_version = _resolve_version(current_version)
+    except UnknownVersionError as e:
+        print(str(e))
+        return 1
 
     documents = []
     for j in json_files:

--- a/src/spdx3_validate/spdx_versions.py
+++ b/src/spdx3_validate/spdx_versions.py
@@ -3,17 +3,24 @@
 # SPDX-FileType: SOURCE
 # SPDX-License-Identifier: MIT
 
-from collections import namedtuple
+from __future__ import annotations
 
-from rdflib import RDF, URIRef
+from typing import Callable, Iterator, NamedTuple, Optional
 
-SpdxVersion = namedtuple(
-    "SpdxVersion",
-    ["context_url", "shacl_url", "schema_url", "pretty", "rdf_base", "get_imports"],
-)
+from rdflib import RDF, Graph, URIRef
+from rdflib.term import Node
 
 
-def get_3_0_0_imports(graph):
+class SpdxVersion(NamedTuple):
+    context_url: str
+    shacl_url: str
+    schema_url: str
+    pretty: str
+    rdf_base: str
+    get_imports: Callable[[Graph], Iterator[Node]]
+
+
+def get_3_0_0_imports(graph: Graph) -> Iterator[Node]:
     RDF_BASE = URIRef("https://spdx.org/rdf/3.0.0/terms/")
 
     for doc in graph.subjects(RDF.type, RDF_BASE + "Core/SpdxDocument"):
@@ -22,7 +29,7 @@ def get_3_0_0_imports(graph):
                 yield spdxid
 
 
-def get_3_0_1_imports(graph):
+def get_3_0_1_imports(graph: Graph) -> Iterator[Node]:
     RDF_BASE = URIRef("https://spdx.org/rdf/3.0.1/terms/")
 
     for doc in graph.subjects(RDF.type, RDF_BASE + "Core/SpdxDocument"):
@@ -51,7 +58,7 @@ SPDX_VERSIONS = (
 )
 
 
-def find_version(context_url):
+def find_version(context_url: str) -> Optional[SpdxVersion]:
     for s in SPDX_VERSIONS:
         if s.context_url == context_url:
             return s

--- a/src/spdx3_validate/spdx_versions.py
+++ b/src/spdx3_validate/spdx_versions.py
@@ -1,5 +1,6 @@
-# Copyright (c) 2024 Joshua Watt
-#
+# SPDX-FileContributor: Joshua Watt
+# SPDX-FileCopyrightText: 2024 Joshua Watt
+# SPDX-FileType: SOURCE
 # SPDX-License-Identifier: MIT
 
 from collections import namedtuple

--- a/src/spdx3_validate/version.py
+++ b/src/spdx3_validate/version.py
@@ -1,1 +1,6 @@
+# SPDX-FileContributor: Joshua Watt
+# SPDX-FileCopyrightText: 2024 Joshua Watt
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: MIT
+
 VERSION = "0.0.6"

--- a/tests/data/3.0.1/invalid/package_sbom_missing_creationinfo.json
+++ b/tests/data/3.0.1/invalid/package_sbom_missing_creationinfo.json
@@ -1,0 +1,97 @@
+{
+    "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+    "@graph": [
+        {
+            "type": "CreationInfo",
+            "@id": "_:creationinfo",
+            "createdBy": [
+                "http://spdx.example.com/Agent/JoshuaWatt"
+            ],
+            "specVersion": "3.0.1",
+            "created": "2024-03-06T00:00:00Z"
+        },
+        {
+            "type": "Person",
+            "spdxId": "http://spdx.example.com/Agent/JoshuaWatt",
+            "name": "Joshua Watt",
+            "externalIdentifier": [
+                {
+                    "type": "ExternalIdentifier",
+                    "externalIdentifierType": "email",
+                    "identifier": "JPEWhacker@gmail.com"
+                }
+            ]
+        },
+        {
+            "type": "SpdxDocument",
+            "spdxId": "http://spdx.example.com/Document1",
+            "creationInfo": "_:creationinfo",
+            "rootElement": [
+                "http://spdx.example.com/BOM1"
+            ],
+            "element": [
+                "http://spdx.example.com/BOM1",
+                "http://spdx.example.com/Agent/JoshuaWatt",
+                "http://spdx.example.com/Package1/myprogram",
+                "http://spdx.example.com/Relationship/1"
+            ],
+            "profileConformance": [
+                "core",
+                "software"
+            ]
+        },
+        {
+            "type": "software_Sbom",
+            "spdxId": "http://spdx.example.com/BOM1",
+            "creationInfo": "_:creationinfo",
+            "rootElement": [
+                "http://spdx.example.com/Package1"
+            ],
+            "element": [
+                "http://spdx.example.com/Package1/myprogram",
+                "http://spdx.example.com/Package1"
+            ],
+            "software_sbomType": [
+                "build"
+            ]
+        },
+        {
+            "type": "software_Package",
+            "spdxId": "http://spdx.example.com/Package1",
+            "creationInfo": "_:creationinfo",
+            "name": "my-package",
+            "software_packageVersion": "1.0.0",
+            "software_downloadLocation": "http://dl.example.com/my-package_1.0.0.tar",
+            "builtTime": "2024-03-06T00:00:00Z",
+            "originatedBy": [
+                "http://spdx.example.com/Agent/JoshuaWatt"
+            ]
+        },
+        {
+            "type": "software_File",
+            "spdxId": "http://spdx.example.com/Package1/myprogram",
+            "creationInfo": "_:creationinfo",
+            "name": "myprogram",
+            "software_primaryPurpose": "executable",
+            "software_additionalPurpose": [
+                "application"
+            ],
+            "software_copyrightText": "Copyright 2024, Joshua Watt",
+            "builtTime": "2024-03-06T00:00:00Z",
+            "originatedBy": [
+                "http://spdx.example.com/Agent/JoshuaWatt"
+            ]
+        },
+        {
+            "type": "Relationship",
+            "spdxId": "http://spdx.example.com/Relationship/1",
+            "creationInfo": "_:creationinfo",
+            "from": "http://spdx.example.com/Package1",
+            "relationshipType": "contains",
+            "to": [
+                "http://spdx.example.com/Package1/myprogram"
+            ],
+            "completeness": "complete"
+        }
+    ]
+}

--- a/tests/data/3.0.1/valid/package_sbom.json
+++ b/tests/data/3.0.1/valid/package_sbom.json
@@ -1,0 +1,98 @@
+{
+    "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+    "@graph": [
+        {
+            "type": "CreationInfo",
+            "@id": "_:creationinfo",
+            "createdBy": [
+                "http://spdx.example.com/Agent/JoshuaWatt"
+            ],
+            "specVersion": "3.0.1",
+            "created": "2024-03-06T00:00:00Z"
+        },
+        {
+            "type": "Person",
+            "spdxId": "http://spdx.example.com/Agent/JoshuaWatt",
+            "name": "Joshua Watt",
+            "creationInfo": "_:creationinfo",
+            "externalIdentifier": [
+                {
+                    "type": "ExternalIdentifier",
+                    "externalIdentifierType": "email",
+                    "identifier": "JPEWhacker@gmail.com"
+                }
+            ]
+        },
+        {
+            "type": "SpdxDocument",
+            "spdxId": "http://spdx.example.com/Document1",
+            "creationInfo": "_:creationinfo",
+            "rootElement": [
+                "http://spdx.example.com/BOM1"
+            ],
+            "element": [
+                "http://spdx.example.com/BOM1",
+                "http://spdx.example.com/Agent/JoshuaWatt",
+                "http://spdx.example.com/Package1/myprogram",
+                "http://spdx.example.com/Relationship/1"
+            ],
+            "profileConformance": [
+                "core",
+                "software"
+            ]
+        },
+        {
+            "type": "software_Sbom",
+            "spdxId": "http://spdx.example.com/BOM1",
+            "creationInfo": "_:creationinfo",
+            "rootElement": [
+                "http://spdx.example.com/Package1"
+            ],
+            "element": [
+                "http://spdx.example.com/Package1/myprogram",
+                "http://spdx.example.com/Package1"
+            ],
+            "software_sbomType": [
+                "build"
+            ]
+        },
+        {
+            "type": "software_Package",
+            "spdxId": "http://spdx.example.com/Package1",
+            "creationInfo": "_:creationinfo",
+            "name": "my-package",
+            "software_packageVersion": "1.0.0",
+            "software_downloadLocation": "http://dl.example.com/my-package_1.0.0.tar",
+            "builtTime": "2024-03-06T00:00:00Z",
+            "originatedBy": [
+                "http://spdx.example.com/Agent/JoshuaWatt"
+            ]
+        },
+        {
+            "type": "software_File",
+            "spdxId": "http://spdx.example.com/Package1/myprogram",
+            "creationInfo": "_:creationinfo",
+            "name": "myprogram",
+            "software_primaryPurpose": "executable",
+            "software_additionalPurpose": [
+                "application"
+            ],
+            "software_copyrightText": "Copyright 2024, Joshua Watt",
+            "builtTime": "2024-03-06T00:00:00Z",
+            "originatedBy": [
+                "http://spdx.example.com/Agent/JoshuaWatt"
+            ]
+        },
+        {
+            "type": "Relationship",
+            "spdxId": "http://spdx.example.com/Relationship/1",
+            "creationInfo": "_:creationinfo",
+            "from": "http://spdx.example.com/Package1",
+            "relationshipType": "contains",
+            "to": [
+                "http://spdx.example.com/Package1/myprogram"
+            ],
+            "completeness": "complete"
+        }
+    ]
+}

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,21 @@
+# SPDX-FileContributor: Arthit Suriyawongkul
+# SPDX-FileCopyrightText: 2026 Joshua Watt
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: MIT
+"""Test import."""
+
+import re
+
+import spdx3_validate
+
+
+def test_public_api_is_importable() -> None:
+    """Test that the public API is importable."""
+    for name in spdx3_validate.__all__:
+        assert hasattr(spdx3_validate, name), name
+
+
+def test_version_is_exposed() -> None:
+    """Test that the version is exposed and looks like a version string."""
+    assert isinstance(spdx3_validate.__version__, str)
+    assert re.match(r"^\d+\.\d+\.\d+", spdx3_validate.__version__)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -57,7 +57,7 @@ def test_validate_no_sources_is_valid() -> None:
 def test_validate_missing_context_raises(tmp_path: Path) -> None:
     """A document without an @context raises SpdxValidateError (no network)."""
     bad = tmp_path / "no_context.json"
-    bad.write_text(json.dumps({"foo": "bar"}))
+    bad.write_text(json.dumps({"foo": "bar"}), encoding="utf-8")
     with pytest.raises(spdx3_validate.SpdxValidateError):
         spdx3_validate.validate(str(bad))
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,0 +1,114 @@
+# SPDX-FileContributor: Arthit Suriyawongkul
+# SPDX-FileCopyrightText: 2026 Joshua Watt
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: MIT
+"""Test the validate() library API and the spdx3validate() CLI entry point."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+import spdx3_validate
+
+DATA_DIR = Path(__file__).parent / "data"
+VALID_DOC = DATA_DIR / "3.0.1" / "valid" / "package_sbom.json"
+INVALID_DOC = DATA_DIR / "3.0.1" / "invalid" / "package_sbom_missing_creationinfo.json"
+
+
+# --- Library API: validate() -------------------------------------------------
+
+
+def test_validate_valid() -> None:
+    """A known-valid document validates with no errors."""
+    try:
+        result = spdx3_validate.validate(str(VALID_DOC))
+    except OSError as e:
+        pytest.skip(f"network unavailable: {e}")
+    assert result.valid
+    assert bool(result) is True
+    assert result.errors == []
+
+
+def test_validate_invalid() -> None:
+    """A known-invalid document reports attributed ValidationError objects."""
+    try:
+        result = spdx3_validate.validate(str(INVALID_DOC))
+    except OSError as e:
+        pytest.skip(f"network unavailable: {e}")
+    assert not result.valid
+    assert not result
+    assert result.errors
+    assert str(result)  # errors render as text
+    for err in result.errors:
+        assert isinstance(err, spdx3_validate.ValidationError)
+        assert err.source == str(INVALID_DOC)
+        assert err.kind in {"schema", "shacl"}
+        assert err.message
+
+
+def test_validate_no_sources_is_valid() -> None:
+    """Validating nothing succeeds without touching the network."""
+    result = spdx3_validate.validate([])
+    assert result.valid
+    assert result.errors == []
+
+
+def test_validate_missing_context_raises(tmp_path: Path) -> None:
+    """A document without an @context raises SpdxValidateError (no network)."""
+    bad = tmp_path / "no_context.json"
+    bad.write_text(json.dumps({"foo": "bar"}))
+    with pytest.raises(spdx3_validate.SpdxValidateError):
+        spdx3_validate.validate(str(bad))
+
+
+def test_validate_unknown_version_raises() -> None:
+    """An unknown version string raises UnknownVersionError (no network)."""
+    with pytest.raises(spdx3_validate.UnknownVersionError):
+        spdx3_validate.validate([], version="9.9.9")
+
+
+def test_error_and_result_rendering() -> None:
+    """ValidationError / ValidationResult render as text (no network)."""
+    err = spdx3_validate.ValidationError("a.json", "shacl", "boom")
+    assert str(err) == "a.json [shacl]: boom"
+
+    result = spdx3_validate.ValidationResult([err])
+    assert not result
+    assert not result.valid
+    assert str(result) == "a.json [shacl]: boom"
+
+
+def test_empty_result_is_valid_and_blank() -> None:
+    """An empty ValidationResult is valid and renders as an empty string."""
+    result = spdx3_validate.ValidationResult()
+    assert result.valid
+    assert bool(result) is True
+    assert str(result) == ""
+
+
+# --- CLI entry point: spdx3validate() (back-compat) --------------------------
+
+
+def test_spdx3validate_is_callable() -> None:
+    """Test that spdx3validate is callable."""
+    # No input files -> nothing to validate -> success (exit code 0)
+    assert spdx3_validate.spdx3validate([]) == 0
+
+
+def test_spdx3validate_valid() -> None:
+    """A known-valid SPDX 3.0.1 document validates successfully."""
+    try:
+        rc = spdx3_validate.spdx3validate([str(VALID_DOC)])
+    except OSError as e:
+        pytest.skip(f"network unavailable: {e}")
+    assert rc == 0
+
+
+def test_spdx3validate_invalid() -> None:
+    """A known-invalid SPDX 3.0.1 document fails validation."""
+    try:
+        rc = spdx3_validate.spdx3validate([str(INVALID_DOC)])
+    except OSError as e:
+        pytest.skip(f"network unavailable: {e}")
+    assert rc != 0


### PR DESCRIPTION
This is a huge PR. I tried to separate it into smaller commits, so it can reviews separately.

The PR is mainly trying to extract the validation logic out of `spdx3validate()` function (and leave only UI-related code, like print and progress bar, there).

- Commit 1 - move core functions from main.py to core.py; these are pure move. No change in behavior.
- Commit 2 - add `validate()` function as main entry point for library call, using original core functions from core.py (originally from main.py)
  - As discussed in 1 July 2026 Implementers call, this function will return list of results
  - Results from jsonschema are tagged with "schema", results from pyshacl are tagged with "shacl".
  - Empty list = no violations/warnings.
- Commit 3 - add tests
- Commit 4 - put tests to CI

`main()` and `spdx3validate()` are working the same way, returning 0/1, so existing scripts should still working.
